### PR TITLE
Support use of Secret objects for Blackfire credentials

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,8 +1,7 @@
 apiVersion: v1
-appVersion: "1.0"
 description: An unofficial helm chart for blackfire.io
 name: blackfire
-version: 0.1.0
+version: 0.2.0
 appVersion: 1.17.0
 home: https://blackfire.io/
 sources:

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -1,8 +1,8 @@
-{{ if eq .Values.blackfire.server_id "" }}
+{{ if and (eq .Values.blackfire.server_id "") (eq .Values.blackfire.existingSecret "") }}
 Blackfire server id cannot be empty, read the official documentation:
 https://blackfire.io/docs/introduction
 
-{{ else if eq .Values.blackfire.server_token "" }}
+{{ else if and (eq .Values.blackfire.server_token "") (eq .Values.blackfire.existingSecret "") }}
 Blackfire server token cannot be empty, read the official documentation:
 https://blackfire.io/docs/introduction
 

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -25,9 +25,23 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: BLACKFIRE_SERVER_ID
+              {{- if .Values.blackfire.existingSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.blackfire.existingSecret }}
+                  key: server_id
+              {{- else }}
               value: {{ .Values.blackfire.server_id }}
+              {{- end }}
             - name: BLACKFIRE_SERVER_TOKEN
+              {{- if .Values.blackfire.existingSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.blackfire.existingSecret }}
+                  key: server_token
+              {{- else }}
               value: {{ .Values.blackfire.server_token }}
+              {{- end }}
           ports:
             - name: agent
               containerPort: 8707

--- a/values.yaml
+++ b/values.yaml
@@ -16,6 +16,10 @@ service:
 blackfire:
   server_id: ""
   server_token: ""
+  # If you want to store your server_id and server_token in a Secret instead, set this value to the name of that Secret.
+  # The server_id and server_token values above will be ignored if this value is set.
+  # Make sure the fields in your Secret are also called server_id and server_token, just like above.
+  existingSecret: ""
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
This change adds support for storing the server_id and server_token values in a Secret object, rather than plain text in your manifest. This is particularly useful when using the GitOps approach, where manifests are committed to Git for everyone to see. You don't want your real credentials ending up in your committed deployments.

This change is backwards compatible. If someone would upgrade to this version, the old approach is still the default one. Only by actually setting a value for `existingSecret`, this new approach is activated.

Example secret:

```yaml
---
apiVersion: v1
kind: Secret
metadata:
  name: blackfire
data:
  server_id: MQ==
  server_token: Zm9v
```

Local test on minikube (where test-values.yaml references the secret above):

```
$ helm install -f test-values.yaml ./                                                                                     
NAME:   elder-rat
LAST DEPLOYED: Tue Feb 19 17:30:14 2019
NAMESPACE: default
STATUS: DEPLOYED

RESOURCES:
==> v1beta2/Deployment
NAME                 DESIRED  CURRENT  UP-TO-DATE  AVAILABLE  AGE
elder-rat-blackfire  1        1        1           0          0s

==> v1/Pod(related)
NAME                                  READY  STATUS             RESTARTS  AGE
elder-rat-blackfire-754995ff75-djrkm  0/1    ContainerCreating  0         0s

==> v1/Service
NAME                 TYPE       CLUSTER-IP      EXTERNAL-IP  PORT(S)  AGE
elder-rat-blackfire  ClusterIP  10.110.208.189  <none>       80/TCP   0s



NOTES:

1. Get the application URL by running these commands:
  export POD_NAME=$(kubectl get pods --namespace default -l "app=blackfire,release=elder-rat" -o jsonpath="{.items[0].metadata.name}")
  echo "Visit http://127.0.0.1:8080 to use your application"
  kubectl port-forward $POD_NAME 8080:80
```

Running with default values file (all empty values, NOTES still work as intended):

```
$ helm install -f values.yaml ./    
NAME:   listless-cardinal
LAST DEPLOYED: Tue Feb 19 17:45:34 2019
NAMESPACE: default
STATUS: DEPLOYED

RESOURCES:
==> v1/Pod(related)
NAME                                         READY  STATUS             RESTARTS  AGE
listless-cardinal-blackfire-d5db47dfc-khl48  0/1    ContainerCreating  0         0s

==> v1/Service
NAME                         TYPE       CLUSTER-IP     EXTERNAL-IP  PORT(S)  AGE
listless-cardinal-blackfire  ClusterIP  10.103.81.250  <none>       80/TCP   0s

==> v1beta2/Deployment
NAME                         DESIRED  CURRENT  UP-TO-DATE  AVAILABLE  AGE
listless-cardinal-blackfire  1        1        1           0          0s


NOTES:

Blackfire server id cannot be empty, read the official documentation:
https://blackfire.io/docs/introduction
```

Unrelated: This also removes the duplicate `appVersion` line from Chart.yaml (is now defined twice, this seems to be the incorrect one).