### PR TITLE
Add BLACKFIRE_LOG_LEVEL env var

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -42,6 +42,8 @@ spec:
               {{- else }}
               value: {{ .Values.blackfire.server_token }}
               {{- end }}
+            - name: BLACKFIRE_LOG_LEVEL
+              value: {{ default "1" .Values.blackfire.log_level }}
           ports:
             - name: agent
               containerPort: 8707

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -43,7 +43,7 @@ spec:
               value: {{ .Values.blackfire.server_token }}
               {{- end }}
             - name: BLACKFIRE_LOG_LEVEL
-              value: {{ default "1" .Values.blackfire.log_level }}
+              value: {{ .Values.blackfire.log_level | default 1 | quote }}
           ports:
             - name: agent
               containerPort: 8707


### PR DESCRIPTION
Hi,

Thanks for the chart. I'm using it

From the docs it's possible to change the log level of the agent: https://blackfire.io/docs/integrations/docker#debugging-the-agent-and-the-php-probe

This PR adds the environment variable for that. Usage would be:

```
--set-string blackfire.blackfire.log_level=4
```